### PR TITLE
[OWL-456] let transfer support nqm-fping metrics

### DIFF
--- a/sender/sender.go
+++ b/sender/sender.go
@@ -2,13 +2,15 @@ package sender
 
 import (
 	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
 	"github.com/Cepave/transfer/g"
 	"github.com/Cepave/transfer/proc"
 	cpool "github.com/Cepave/transfer/sender/conn_pool"
 	cmodel "github.com/open-falcon/common/model"
 	nlist "github.com/toolkits/container/list"
-	"log"
-	"strconv"
 )
 
 const (
@@ -252,7 +254,7 @@ func Demultiplex(items []*cmodel.MetaData) ([]*cmodel.MetaData, []*cmodel.MetaDa
 	generics := []*cmodel.MetaData{}
 
 	for _, item := range items {
-		if item.Metric == "nqm-metrics" {
+		if strings.HasPrefix(item.Metric, "nqm-") {
 			nqms = append(nqms, item)
 		} else {
 			generics = append(generics, item)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,9 @@
+## How to use
+1. to see the statistical information of transfer
+./debug
+
+2. to send a nqm packet to transfer
+./debug nqm
+
+3. to send a batch of nqm packets to transfer
+./debug nqmbatch

--- a/test/debug
+++ b/test/debug
@@ -72,7 +72,7 @@ function http_post(){
 
 function nqm(){
     e="test.endpoint.niean.2"
-    m="nqm-metrics"
+    m="nqm-fping"
     t="rttmin=18.64, rttavg=21.5, rttmax=26.9, rttmdev=4.7, pkttransmit=13, pktreceive=11, agent-id=1334, agent-isp-id=12, agent-province-id=13, agent-city-id=14, agent-name-tag-id=123, target-id=2334, target-isp-id=22, target-province-id=23, target-city-id=24, target-name-tag-id=223"
     ts=`date +%s`
     val=`expr $ts / 60 % 10`
@@ -82,7 +82,7 @@ function nqm(){
 
 function nqm_copy(){
     e="test.endpoint.niean.2"
-    m="nqm-metrics"
+    m="nqm-fping"
     ts=`date +%s`
     val=`expr $ts / 60 % 10`
     rand=$RANDOM


### PR DESCRIPTION
Originally, transfer supports the packet with  metric name as "nqm-metrics" to Cassandra. 
Now, transfer supports the packet with metric name as prefix "nqm-" to Cassandra. 
